### PR TITLE
fix: restrict allowed hosts to prevent host header poisoning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       PB_DEBUGLOG: debug.log
       PB_DEBUGLOGLEVEL: Debug,
       PB_DEBUGLOGRETAINCOUNT: 3
+      PB_ALLOWEDHOSTS: ${PB_HOST}
       PB_GITHUB_TOKEN: ${PB_GITHUB_TOKEN}
       VIRTUAL_HOST_NAME: pluginbuilder
       VIRTUAL_HOST: ${PB_HOST}


### PR DESCRIPTION
Additionally harden hosts after https://github.com/btcpayserver/btcpayserver-plugin-builder-infra/commit/c9ff7d2966cb6744383060d1cbcfc505fd953736